### PR TITLE
記事作成のAPIとテストの実装、CSRF対策も追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -7,7 +7,18 @@ module Api::V1
 
     def show
       article = Article.find(params[:id])
-      render json: article, each_serializer: Api::V1::ArticleSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session #CSRF対策
   include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,6 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -49,4 +49,22 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+
+    # stub
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事のレコードが作成できる" do
+      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
- 記事の作成はログインユーザーしかできないように実装
- base_api_controllerにダミーのcurrent_userメソッドを定義
- CSRF対策を追加
- ログインユーザーだけが記事の作成をできるようにテスト