### PR TITLE
デプロイ時のエラーにより、bundle lock --add-platform x86_64-linux を実行

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.2.1.1)
@@ -320,6 +322,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)


### PR DESCRIPTION
## 概要
 M2Macでは対応していないためbundle lock --add-platform x86_64-linuxでエラーを解消